### PR TITLE
Fixed compiling with SRL-OSR

### DIFF
--- a/lib/core/Math.simba
+++ b/lib/core/Math.simba
@@ -8,6 +8,7 @@ Supporting math functions.
 
 *)
 {$IFNDEF AL}
+{$IFNDEF SRL5}
 const
   MATH_PI = 3.14159265358979320;
   MATH_2PI = MATH_PI * 2.0;
@@ -35,6 +36,7 @@ const
   __gauss_norm_2 = 0.076542912;
   __gauss_norm_3 = 0.252408784;
   __gauss_norm_4 = 3.949846138;
+{$ENDIF SRL5}
 {$ENDIF AL}
 
 (*

--- a/lib/internal/Globals.simba
+++ b/lib/internal/Globals.simba
@@ -216,6 +216,7 @@ const
   Widget_Magic_Container = 218;
 
 {$IFNDEF AL}
+{$IFNDEF SRL5}
     {Keyboard}
 
   Vk_Enter = {$IFDEF LINUX}10{$ELSE}Vk_Return{$ENDIF};
@@ -257,6 +258,7 @@ const
   Time_Bare   = 3;
   Time_Fstop  = 4;
 
+{$ENDIF SRL5}
 {$ENDIF AL}
 
     {Login}

--- a/lib/internal/Graphics.simba
+++ b/lib/internal/Graphics.simba
@@ -1,6 +1,7 @@
 {Credits to Flight & AeroLib for most of Graphics.simba}
 
 {$IFNDEF AL}
+{$IFNDEF SRL5}
 const
   clBlack = 0;
   clWhite = 16777215;
@@ -21,6 +22,7 @@ const
   clMaroon = 128;
   clOutline_black = 65536;
   clOutline_white = 16777215;
+{$ENDIF SRL5}
 {$ENDIF AL}
 
 var


### PR DESCRIPTION
Added a few `{$IFNDEF SRL5}`'s for functions that were throwing duplicate
declaration errors.

NOTE: This does require https://github.com/SRL/SRL-OSR/pull/143 and shouldn't be accepted until/unless that is accepted.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/Elfyyy/OSR-Reflection/pull/41%23issuecomment-73688089%22%2C%20%22https%3A//github.com/Elfyyy/OSR-Reflection/pull/41%23issuecomment-73767479%22%2C%20%22https%3A//github.com/Elfyyy/OSR-Reflection/pull/41%23issuecomment-73818590%22%2C%20%22https%3A//github.com/Elfyyy/OSR-Reflection/pull/41%23issuecomment-74303505%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/Elfyyy/OSR-Reflection/pull/41%23issuecomment-73688089%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20just%20realized%20this%20does%20not%20work%20with%20https%3A//github.com/SRL/SRL-OSR/pull/143.%20I%27m%20not%20sure%20if%20I%20messed%20something%20up%20in%20this%20PR%20or%20that%20one%2C%20but%20I%27m%20getting%20an%20error%20related%20to%20SMART%20when%20trying%20to%20compile%20the%20following%20with%20this%20and%20https%3A//github.com/SRL/SRL-OSR/pull/143%3A%5Cr%5Cn%5Cr%5Cn%60%60%60Pascal%5Cr%5Cn%7B%24define%20smart%7D%5Cr%5Cn%7B%24i%20srl-osr/srl.simba%7D%5Cr%5Cn%7B%24i%20reflection/reflection.simba%7D%5Cr%5Cn%5Cr%5Cnbegin%5Cr%5Cn%20%20setupsrl%28%29%3B%5Cr%5Cn%20%20reflect.Setup%28%29%3B%5Cr%5Cnend.%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnError%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnERROR%20comes%20from%20a%20non-existing%20file%20%28%21addGlobalFuncHdr%29%5Cr%5CnError%3A%20Duplicate%20declaration%20%5C%22SmartGetClients%5C%22%20at%20line%201%5Cr%5CnCompiling%20failed.%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-02-10T11%3A57%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7721597%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ianhedoesit%22%7D%7D%2C%20%7B%22body%22%3A%20%22Isn%27t%20SRL-OSR%20being%20phased%20out%3F%22%2C%20%22created_at%22%3A%20%222015-02-10T19%3A35%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8165365%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/SRLTheMayor%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40SRLTheMayor%20I%20don%27t%20know.%20I%20just%20know%20that%20a%20lot%20of%20people%20ask%20about%20using%20this%20with%20SRL-OSR.%20If%20the%20only%20thing%20that%20needs%20changing%20is%20a%20few%20lines%20that%20don%27t%20change%20anything%20if%20you%20use%20AeroLib%2C%20then%20I%20don%27t%20see%20the%20harm.%22%2C%20%22created_at%22%3A%20%222015-02-11T01%3A13%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7721597%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ianhedoesit%22%7D%7D%2C%20%7B%22body%22%3A%20%22Not%20going%20to%20make%20this%20include%20compatible%20with%20srl-osr.%22%2C%20%22created_at%22%3A%20%222015-02-13T18%3A40%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4069146%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/Elfyyy%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/Elfyyy/OSR-Reflection/pull/41#issuecomment-73688089'>General Comment</a></b>
- <a href='https://github.com/ianhedoesit'><img border=0 src='https://avatars.githubusercontent.com/u/7721597?v=3' height=16 width=16'></a> I just realized this does not work with https://github.com/SRL/SRL-OSR/pull/143. I'm not sure if I messed something up in this PR or that one, but I'm getting an error related to SMART when trying to compile the following with this and https://github.com/SRL/SRL-OSR/pull/143:

``` Pascal
{$define smart}
{$i srl-osr/srl.simba}
{$i reflection/reflection.simba}
begin
setupsrl();
reflect.Setup();
end.
```

Error:

```
ERROR comes from a non-existing file (!addGlobalFuncHdr)
Error: Duplicate declaration "SmartGetClients" at line 1
Compiling failed.
```
- <a href='https://github.com/SRLTheMayor'><img border=0 src='https://avatars.githubusercontent.com/u/8165365?v=3' height=16 width=16'></a> Isn't SRL-OSR being phased out?
- <a href='https://github.com/ianhedoesit'><img border=0 src='https://avatars.githubusercontent.com/u/7721597?v=3' height=16 width=16'></a> @SRLTheMayor I don't know. I just know that a lot of people ask about using this with SRL-OSR. If the only thing that needs changing is a few lines that don't change anything if you use AeroLib, then I don't see the harm.
- <a href='https://github.com/Elfyyy'><img border=0 src='https://avatars.githubusercontent.com/u/4069146?v=3' height=16 width=16'></a> Not going to make this include compatible with srl-osr.

<a href='https://www.codereviewhub.com/Elfyyy/OSR-Reflection/pull/41?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/Elfyyy/OSR-Reflection/pull/41?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/Elfyyy/OSR-Reflection/pull/41'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
