### PR TITLE
Added a proper TReflectActor.IsMoving

### DIFF
--- a/lib/core/renderable/Actor.simba
+++ b/lib/core/renderable/Actor.simba
@@ -16,6 +16,13 @@ begin
     Reflect.Smart.GetFieldInt(Self.Reference, Actor_WorldY) div 128;
 end;
 
+function TReflectActor.GetQueueSize: Integer;
+begin
+  if Reflect.Smart.IsNull(Self.Reference) then
+    Exit(-1);
+  Result := Reflect.Smart.GetFieldInt(Self.Reference, Actor_QueueSize);
+end;
+
 function TReflectActor.GetQueue(Index: Integer = 0): TTile;
 begin
   if Reflect.Smart.IsNull(Self.Reference) then
@@ -63,10 +70,7 @@ end;
 
 function TReflectActor.IsMoving: Boolean;
 begin
-  if Reflect.Smart.IsNull(Self.Reference) then
-    Exit;
-  Result := (Self.GetQueue.X <> Self.GetTile.X) or
-    (Self.GetQueue.Y <> Self.GetTile.Y);
+  Result := (Self.GetQueueSize > 0);
 end;
 
 function TReflectActor.IsUnderAttack: Boolean;

--- a/lib/internal/Hooks.simba
+++ b/lib/internal/Hooks.simba
@@ -34,6 +34,7 @@ const
  Actor_Animation: THook =             ['bj', -129982891];
  Actor_QueueX: THook =                ['bd', 1];
  Actor_QueueY: THook =                ['bu', 1];
+ Actor_QueueSize: THook =             ['bl', 370637597];
  Actor_WorldX: THook =                ['g', 714387585];
  Actor_WorldY: THook =                ['f', 443183909];
  Actor_SpokenText: THook =            ['al', 1];
@@ -63,8 +64,8 @@ const
  Widget_IsHidden: THook =             ['ap', 1];
  Widget_AbsoluteX: THook =            ['d', 280533711];
  Widget_AbsoluteY: THook =            ['ax', 150978763];
- Widget_RelativeX: THook =            ['null', 1];
- Widget_RelativeY: THook =            ['null', 1];
+ Widget_RelativeX: THook =            ['d', 280533711];
+ Widget_RelativeY: THook =            ['ax', 150978763];
  Widget_Width: THook =                ['ag', -978834493];
  Widget_Height: THook =               ['ai', -62917981];
  Widget_ParentID: THook =             ['ac', -513345053];
@@ -121,8 +122,8 @@ const
  Client_CurrentLevels: THook =        ['client.hf', 1];
  Client_RealLevels: THook =           ['client.hw', 1];
  Client_Experiences: THook =          ['client.hv', 1];
- Client_Energy: THook =               ['client.k', -462981805];
- Client_Weight: THook =               ['client.jq', 1485798329];
+ Client_Energy: THook =               ['client.jq', 1485798329];
+ Client_Weight: THook =               ['client.js', 295576965];
  Client_Rights: THook =               ['client.h', -2061225245];
  Client_CurrentWorld: THook =         ['client.ar', -939231799];
  Client_LoginState: THook =           ['client.c', -2061786953];

--- a/lib/misc/Misc.simba
+++ b/lib/misc/Misc.simba
@@ -74,7 +74,9 @@ begin
   Result := VarType(v) = VarBoolean;
 end;
 
-{$loadlib prosocks}
+{$IFNDEF Aerolib}
+  {$loadlib prosocks}
+{$ENDIF}
 Function TReflectionMisc.GetPage(Url: string): string;
 var
   S: SSLSocket;


### PR DESCRIPTION
Works on many-tiled NPCs aswell
getQueue is left untouched as it cna still be usefull.

Small hook fixes for energy/weight.

Elfyyy, add GetQueueSize to your updater, very useful! Also Relative/Absolute is same?
