### PR TITLE
Fixes TReflectionKeyboard.Format

### DIFF
--- a/lib/core/input/Keyboard.simba
+++ b/lib/core/input/Keyboard.simba
@@ -127,7 +127,7 @@ begin
                 ButtonString,
                 Code:=ReplaceRegExpr('(?i)^([a-z]+|\d[0-5]?|[^a-z])( \d+| down| up)?$', ButtonString, '$1', True),
                 toStr(Self.Code(Code)),
-                [0]
+                [rfReplaceAll]
               )+'}';
         end
         else


### PR DESCRIPTION
Fixed TReflectionKeyboard.Format causing an access violation when used with AeroLib.
