### PR TITLE
Make GetSkillExp work with Total XP

### DIFF
--- a/lib/core/renderable/LocalPlayer.simba
+++ b/lib/core/renderable/LocalPlayer.simba
@@ -107,8 +107,14 @@ begin
 end;
 
 function TReflectLocalPlayer.GetSkillExp(SkillConst: Integer): Integer;
+var
+  i: integer;
 begin
-  Result := Reflect.Smart.GetFieldArrayInt(0, Client_Experiences, SkillConst);
+  if SkillConst <> SKILL_TOTAL then
+    Result := Reflect.Smart.GetFieldArrayInt(0, Client_Experiences, SkillConst)
+  else
+    for i := 0 to SKILL_COUNT - 1 do
+      Result := Result + Reflect.Smart.GetFieldArrayInt(0, Client_Experiences, i);
 end;
 
 function TReflectLocalPlayer.GetCurrentWorld: Integer;


### PR DESCRIPTION
Not sure if this is the proper way to do it, or if reflection can actually get the XP directly (it probably can).  But either way, `ReflectLocalPlayer.GetSkillExp(SKILL_TOTAL)` would always return 0.  Now it returns the proper xp.
